### PR TITLE
Use a DB path that survives reboots

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func (argSpec) Version() string {
 func procArgs() argSpec {
 	// Set argument default values.
 	args := argSpec{
-		DBPath:   "/var/run/event-reporter.db",
+		DBPath:   "/var/lib/event-reporter.db",
 		Interval: 30 * time.Minute,
 	}
 	arg.MustParse(&args)


### PR DESCRIPTION
/var/run is a symlink to a tmpfs mount point.

Also added a unit test to confirm persistence between DB opens.