### PR TITLE
Fix empty details migration

### DIFF
--- a/eventstore/eventstore_test.go
+++ b/eventstore/eventstore_test.go
@@ -88,6 +88,9 @@ func (s *Suite) TestMigrate() {
 			},
 			"type": "audiobait2",
 		},
+		t.Add(time.Second).Unix(): {
+			"type": "audiobait2",
+		},
 	}
 	log.Printf("events to migrate %+v", e)
 	// Adding some event using the old method
@@ -117,8 +120,10 @@ func (s *Suite) TestMigrate() {
 		s.NoError(json.Unmarshal(detailsBytes, event))
 		i := e[event.Timestamp.Unix()]
 		log.Printf("event time %d", event.Timestamp.Unix())
-		s.Equal(i["type"], event.Description.Type)       // Checkign that type was properly migrated
-		s.Equal(i["details"], event.Description.Details) // Checkign that details was properly migrated
+		s.Equal(i["type"], event.Description.Type) // Checkign that type was properly migrated
+		if _, ok := i["details"]; ok {             // Only compare details if origional data had details
+			s.Equal(i["details"], event.Description.Details) // Checkign that details was properly migrated
+		}
 	}
 
 	// Check that migrated events are deleted

--- a/eventstore/eventstore_test.go
+++ b/eventstore/eventstore_test.go
@@ -120,9 +120,9 @@ func (s *Suite) TestMigrate() {
 		s.NoError(json.Unmarshal(detailsBytes, event))
 		i := e[event.Timestamp.Unix()]
 		log.Printf("event time %d", event.Timestamp.Unix())
-		s.Equal(i["type"], event.Description.Type) // Checkign that type was properly migrated
+		s.Equal(i["type"], event.Description.Type) // Checking that type was properly migrated
 		if _, ok := i["details"]; ok {             // Only compare details if origional data had details
-			s.Equal(i["details"], event.Description.Details) // Checkign that details was properly migrated
+			s.Equal(i["details"], event.Description.Details) // Checking that details was properly migrated
 		}
 	}
 


### PR DESCRIPTION
- Some old events didn't have any details, only a event. This was causing the migration to fail.
- Copy keys and values from boltdb  in migration transactions to prevent 'unexpected fault address' errors.