### PR TITLE
Add version reporter

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,7 @@ nfpms:
   files:
     "_release/event-reporter.service": "/etc/systemd/system/event-reporter.service"
     "_release/service-watcher.service": "/etc/systemd/system/service-watcher.service"
+    "_release/version-reporter.service": "/etc/systemd/system/version-reporter.service"
     "_release/org.cacophony.Events.conf": "/etc/dbus-1/system.d/org.cacophony.Events.conf"
   scripts:
     postinstall: "_release/postinstall.sh"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,13 +30,24 @@ builds:
     - "7"
   ldflags: -s -w -X main.version={{.Version}}
 
+- id: version-reporter
+  binary: version-reporter
+  main: ./cmd/version-reporter
+  goos:
+    - linux
+  goarch:
+    - arm
+  goarm:
+    - "7"
+  ldflags: -s -w -X main.version={{.Version}}
+
 nfpms:
 - vendor: The Cacophony Project
   homepage: http://cacophony.org.nz/
   maintainer: Cacophony Developers <coredev@cacophony.org.nz>
   description: Queue and report events to the Cacophony Project API
   license: GPL v3.0
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}"
+  file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}"
   formats:
     - deb
   bindir: /usr/bin

--- a/_release/postinstall.sh
+++ b/_release/postinstall.sh
@@ -7,3 +7,5 @@ systemctl restart event-reporter.service
 
 systemctl enable service-watcher.service
 systemctl restart service-watcher.service
+
+systemctl enable version-reporter.service

--- a/_release/version-reporter.service
+++ b/_release/version-reporter.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Report the version of cacophony software running
+After=multi-user.target network.target event-reporter.service
+
+[Service]
+ExecStart=/usr/bin/version-reporter
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target

--- a/cmd/event-reporter/main.go
+++ b/cmd/event-reporter/main.go
@@ -77,7 +77,9 @@ func runMain() error {
 
 	cr := connrequester.NewConnectionRequester()
 
-	err = StartService(store)
+	uploadEventsChan := make(chan bool)
+
+	err = StartService(store, uploadEventsChan)
 	if err != nil {
 		return err
 	}
@@ -94,7 +96,11 @@ func runMain() error {
 			sendEvents(store, eventKeys, cr)
 		}
 
-		time.Sleep(args.Interval)
+		select {
+		case <-uploadEventsChan:
+			log.Println("events upload requested")
+		case <-time.After(args.Interval):
+		}
 	}
 }
 

--- a/cmd/version-reporter/main.go
+++ b/cmd/version-reporter/main.go
@@ -19,11 +19,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package main
 
 import (
-	"encoding/json"
 	"log"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
+
+	"github.com/TheCacophonyProject/event-reporter/eventclient"
 )
 
 func main() {
@@ -40,17 +42,22 @@ func runMain() error {
 	if err != nil {
 		return err
 	}
-	packageJSONData, err := json.Marshal(packageMpedData)
-	if err != nil {
+
+	event := eventclient.Event{
+		Timestamp: time.Now(),
+		Type:      "versionData",
+		Details:   packageMpedData,
+	}
+	if err := eventclient.AddEvent(event); err != nil {
 		return err
 	}
-	log.Println(string(packageJSONData))
+	log.Println("added verionData event")
 
 	return nil
 }
 
 // Return info on the packages that are currently installed on the device.
-func getInstalledPackages() (map[string]string, error) {
+func getInstalledPackages() (map[string]interface{}, error) {
 
 	if runtime.GOOS == "windows" {
 		return nil, nil
@@ -66,7 +73,7 @@ func getInstalledPackages() (map[string]string, error) {
 	}
 	packagesData := string(out)
 	// Want to separate this into separate fields so that can display in a table in HTML
-	data := map[string]string{}
+	data := map[string]interface{}{}
 	rows := strings.Split(packagesData, "\n")
 	for _, row := range rows {
 		// We only want packages related to cacophony.

--- a/cmd/version-reporter/main.go
+++ b/cmd/version-reporter/main.go
@@ -52,6 +52,10 @@ func runMain() error {
 	for i := 3; i > 0; i-- {
 		err := eventclient.AddEvent(event)
 		if err == nil {
+			log.Println("added verionData event")
+			if err := eventclient.UploadEvents(); err != nil {
+				return err
+			}
 			break
 		}
 		if i == 1 {
@@ -61,7 +65,6 @@ func runMain() error {
 		log.Println("failed to log event. Will retry in 5 seconds")
 		time.Sleep(5 * time.Second)
 	}
-	log.Println("added verionData event")
 
 	return nil
 }

--- a/cmd/version-reporter/main.go
+++ b/cmd/version-reporter/main.go
@@ -48,8 +48,18 @@ func runMain() error {
 		Type:      "versionData",
 		Details:   packageMpedData,
 	}
-	if err := eventclient.AddEvent(event); err != nil {
-		return err
+
+	for i := 3; i > 0; i-- {
+		err := eventclient.AddEvent(event)
+		if err == nil {
+			break
+		}
+		if i == 1 {
+			log.Println(err)
+			break
+		}
+		log.Println("failed to log event. Will retry in 5 seconds")
+		time.Sleep(5 * time.Second)
 	}
 	log.Println("added verionData event")
 

--- a/cmd/version-reporter/main.go
+++ b/cmd/version-reporter/main.go
@@ -1,0 +1,81 @@
+/*
+version-reporter - report event containing the version of all cacophony software at boot.
+Copyright (C) 2020, The Cacophony Project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func main() {
+	err := runMain()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func runMain() error {
+	log.SetFlags(0) // Removes default timestamp flag
+
+	packageMpedData, err := getInstalledPackages()
+	if err != nil {
+		return err
+	}
+	packageJSONData, err := json.Marshal(packageMpedData)
+	if err != nil {
+		return err
+	}
+	log.Println(string(packageJSONData))
+
+	return nil
+}
+
+// Return info on the packages that are currently installed on the device.
+func getInstalledPackages() (map[string]string, error) {
+
+	if runtime.GOOS == "windows" {
+		return nil, nil
+	}
+
+	out, err := exec.Command(
+		"/usr/bin/dpkg-query",
+		"--show",
+		"--showformat",
+		"${Package}|${Version}|${Maintainer}\n").Output()
+	if err != nil {
+		return nil, err
+	}
+	packagesData := string(out)
+	// Want to separate this into separate fields so that can display in a table in HTML
+	data := map[string]string{}
+	rows := strings.Split(packagesData, "\n")
+	for _, row := range rows {
+		// We only want packages related to cacophony.
+		if !strings.Contains(strings.ToUpper(row), "CACOPHONY") {
+			continue
+		}
+		words := strings.Split(strings.TrimSpace(row), "|")
+		data[words[0]] = words[1]
+	}
+
+	return data, nil
+}

--- a/eventclient/eventclient.go
+++ b/eventclient/eventclient.go
@@ -90,6 +90,12 @@ func DeleteEvent(key uint64) error {
 	return err
 }
 
+// UploadEvents wil reuqest for the events to be uploaded now
+func UploadEvents() error {
+	_, err := eventsDbusCall("org.cacophony.Events.UploadEvents")
+	return err
+}
+
 func eventsDbusCall(method string, params ...interface{}) ([]interface{}, error) {
 	conn, err := dbus.SystemBus()
 	if err != nil {


### PR DESCRIPTION
Added `version-reporter` that will upload a event of type `versionData`. Example of details from an event: 
```
{
  "modemd": "1.0.0~SNAPSHOT-9a7675b",
  "audiobait": "2.0.0",
  "rtc-utils": "1.3.0",
  "event-reporter": "3.1.0~SNAPSHOT-9b67929",
  "device-register": "1.1.0",
  "cacophony-config": "1.3.1",
  "thermal-recorder": "2.6.0",
  "thermal-uploader": "2.2.0",
  "attiny-controller": "3.3.0",
  "management-interface": "1.6.0"
}
```
This will get run on boot.