### PR TITLE
Upload logs when there is an error.

### DIFF
--- a/cmd/event-reporter/main.go
+++ b/cmd/event-reporter/main.go
@@ -315,9 +315,10 @@ func uploadDevicesLogs() {
 		log.Info("Uploading device logs")
 
 		logSince := errTime.Add(-time.Hour * 12) // Get logs from 12 hours before the first error
-		if time.Since(logSince) > 7*24*time.Hour {
-			log.Info("Limiting logs to one week.")
-			logSince = time.Now().Add(-time.Hour * 24 * 7)
+		oneMonth := 31 * 24 * time.Hour
+		if time.Since(logSince) > oneMonth {
+			log.Info("Limiting logs to one month.")
+			logSince = time.Now().Add(-oneMonth)
 		}
 
 		log.Infof("Uploading device logs since %s", logSince.Format(time.DateTime))

--- a/cmd/event-reporter/service.go
+++ b/cmd/event-reporter/service.go
@@ -102,6 +102,10 @@ func (svc *service) Queue(details []byte, nanos int64) *dbus.Error {
 }
 
 func (svc *service) Add(detailsRaw string, eventType string, unixNsec int64) *dbus.Error {
+	log.Info(eventType)
+	if eventType == "systemError" && getSystemErrorTime().IsZero() {
+		setSystemErrorTime(time.Now())
+	}
 	details := map[string]interface{}{}
 	if err := json.Unmarshal([]byte(detailsRaw), &details); err != nil {
 		return dbusErr("", err)

--- a/cmd/event-reporter/service.go
+++ b/cmd/event-reporter/service.go
@@ -129,8 +129,8 @@ func (svc *service) Add(detailsRaw string, eventType string, unixNsec int64) *db
 	if details[eventclient.SeverityKey] == eventclient.SeverityError {
 		log.Info("Event severity: ", details[eventclient.SeverityKey])
 		log.Debugf("Event: %+v", event)
-		if getSystemErrorTime().IsZero() {
-			setSystemErrorTime(time.Now())
+		if getSeverityErrorTime().IsZero() {
+			setSeverityErrorTime(time.Now())
 		}
 	}
 

--- a/cmd/event-reporter/service.go
+++ b/cmd/event-reporter/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/godbus/dbus"
 	"github.com/godbus/dbus/introspect"
 
+	"github.com/TheCacophonyProject/event-reporter/v3/eventclient"
 	"github.com/TheCacophonyProject/event-reporter/v3/eventstore"
 	"github.com/TheCacophonyProject/go-utils/saltutil"
 )
@@ -102,14 +103,14 @@ func (svc *service) Queue(details []byte, nanos int64) *dbus.Error {
 }
 
 func (svc *service) Add(detailsRaw string, eventType string, unixNsec int64) *dbus.Error {
-	log.Info(eventType)
-	if eventType == "systemError" && getSystemErrorTime().IsZero() {
-		setSystemErrorTime(time.Now())
-	}
+	log.Debugf("Adding event: %s, type: %s, unixNsec: %d", detailsRaw, eventType, unixNsec)
 	details := map[string]interface{}{}
-	if err := json.Unmarshal([]byte(detailsRaw), &details); err != nil {
-		return dbusErr("", err)
+	if detailsRaw != "" && detailsRaw != "null" {
+		if err := json.Unmarshal([]byte(detailsRaw), &details); err != nil {
+			return dbusErr("", err)
+		}
 	}
+	log.Debug("Details: ", details)
 	environment, err := saltutil.GetNodegroupFromFile()
 	if err != nil {
 		log.Errorf("failed to read nodegroup file: %v", err)
@@ -125,7 +126,18 @@ func (svc *service) Add(detailsRaw string, eventType string, unixNsec int64) *db
 		},
 	}
 
-	return dbusErr(".Errors.AddFailed", svc.store.Add(event))
+	if details[eventclient.SeverityKey] == eventclient.SeverityError {
+		log.Info("Event severity: ", details[eventclient.SeverityKey])
+		log.Debugf("Event: %+v", event)
+		if getSystemErrorTime().IsZero() {
+			setSystemErrorTime(time.Now())
+		}
+	}
+
+	if err := svc.store.Add(event); err != nil {
+		return dbusErr(".Errors.AddFailed", err)
+	}
+	return nil
 }
 
 func (svc *service) Get(key uint64) (string, *dbus.Error) {

--- a/cmd/service-watcher/main.go
+++ b/cmd/service-watcher/main.go
@@ -185,10 +185,11 @@ func runMain() error {
 				Timestamp: ts,
 				Type:      "systemError",
 				Details: map[string]interface{}{
-					"version":     version,
-					"unitName":    unitName,
-					"logs":        rawLogs,
-					"activeState": activeState,
+					"version":               version,
+					"unitName":              unitName,
+					"logs":                  rawLogs,
+					"activeState":           activeState,
+					eventclient.SeverityKey: eventclient.SeverityError,
 				},
 			}
 			if err := eventclient.AddEvent(event); err != nil {

--- a/eventclient/eventclient.go
+++ b/eventclient/eventclient.go
@@ -28,6 +28,14 @@ import (
 	"github.com/TheCacophonyProject/event-reporter/v3/eventstore"
 )
 
+// Severity can be added in the events Details map. This is to help alert us and the users of potential issues.
+const (
+	SeverityKey     = "severity"
+	SeverityInfo    = "info"    // Just for logging; no action needed.
+	SeverityWarning = "warning" // User attention might be required (e.g., low battery).
+	SeverityError   = "error"   // Something went wrong.
+)
+
 type Event struct {
 	Timestamp time.Time
 	Type      string

--- a/eventstore/eventstore.go
+++ b/eventstore/eventstore.go
@@ -205,7 +205,7 @@ type EventDescription struct {
 }
 
 func (s *EventStore) Add(event *Event) error {
-	log.Printf("adding new %s event\n", event.Description.Type)
+	log.Printf("Adding new '%s' event\n", event.Description.Type)
 	data, err := json.Marshal(event)
 	if err != nil {
 		return err


### PR DESCRIPTION
If a event is created with a severity of error then it will upload the logs from 12 hours before the event was created.
This is to help us debug cameras that are having errors as the logs should automatically get uploaded.
Currently the only events that have a severity of error are system errors (service failing) but more will be added. 
